### PR TITLE
2 feat display memo card

### DIFF
--- a/assets/css/style.css
+++ b/assets/css/style.css
@@ -1,0 +1,16 @@
+#game {
+    --grid-height : 5; /* Nombre de lignes de cartes */
+    --grid-width : 5; /* Nombre de cartes par ligne */
+    display: grid;
+    grid-template-columns: repeat(var(--grid-width), 1fr);
+    grid-template-rows: repeat(var(--grid-height), 1fr);
+    gap: 10px;
+    max-width: 800px;
+    margin: auto;
+}
+
+.card {
+    background-color: aliceblue;
+    width: 100%;
+    height: 100%;
+}

--- a/game.php
+++ b/game.php
@@ -1,0 +1,24 @@
+<?php
+
+$game_width = 5; // Nombre de cartes par ligne
+$game_height = 5; // Nombre de lignes de cartes
+
+?>
+<!DOCTYPE html>
+<html lang="fr">
+
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <link rel="stylesheet" href="/assets/css/game.css">
+    <title>Mémo</title>
+</head>
+
+<body>
+    <h1>Jeu de mémo !</h1>
+    <div id="game">
+
+    </div>
+</body>
+
+</html>

--- a/game.php
+++ b/game.php
@@ -17,7 +17,22 @@ $game_height = 5; // Nombre de lignes de cartes
 <body>
     <h1>Jeu de mémo !</h1>
     <div id="game">
-
+        <?php for ($i = 0; $i < $game_height; $i++) : ?>
+            <div class="row">
+                <?php for ($j = 0; $j < $game_width; $j++) : ?>
+                    <div class="card" data-row="<?= $i ?>" data-col="<?= $j ?>">
+                        <div class="card-inner">
+                            <div class="card-front">
+                                <img src="/assets/images/card-back.png" alt="Carte">
+                            </div>
+                            <div class="card-back">
+                                <img src="/assets/images/card-front.png" alt="Carte">
+                            </div>
+                        </div>
+                    </div>
+                <?php endfor; ?>
+            </div>
+        <?php endfor; ?>
     </div>
 </body>
 


### PR DESCRIPTION
This pull request introduces the initial structure and styling for a memory game ("Mémo") web page. The main changes include creating the basic game grid in `game.php` and defining its appearance in the CSS. The grid is set up to be 5x5, with each cell representing a card that can be flipped.

**Game grid implementation:**

* [`game.php`](diffhunk://#diff-cefb1d3c6904be25995fb5c37a39955550c99f7391b0feb1bc189526a01d6760R1-R39): Generates a 5x5 grid of cards using nested PHP loops. Each card includes front and back faces with placeholder images.

**Styling and layout:**

* [`assets/css/style.css`](diffhunk://#diff-a72d4ee198d130c997b203ecb2f5c54d84617b3cdf7bd9eaab804be78e2709aeR1-R16): Adds CSS rules for the game grid and card elements, including grid layout, card sizing, and basic background color.

Closes : #1, #2 